### PR TITLE
Clarify creating pages section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,7 @@ layout.
 
 ### Customizing and adding content
 Adding content is as simple as creating `*.html`, or `*.md` files and filling
-them with content. Each file in the project directory gets copied to the build
-directory, i.e. `_site` on `jekyll build` and is accessible via the same
-relative path on the server.
-
+them with content.
 Additionally, you should specify at least two properties in each file's [YAML
 front matter section](https://jekyllrb.com/docs/frontmatter/), to tell jekyll
 that you want to embed your content in the default layout and to give the
@@ -72,6 +69,13 @@ layout: default
 css_id: my-funky-page
 ---
 ```
+
+When running `jekyll build` each file in the project directory gets processed,
+e.g. embedded in the the specified layout, and, in the case of markdown,
+converted to `HTML`. The result is copied to the build directory, i.e. `_site`,
+preserving relative paths, but changing the file extension to `.html`.
+You can read more about [creating pages in the jekyll
+docs](https://jekyllrb.com/docs/pages/).
 
 ### Adding assets
 Add assets, e.g. images or JavaScript, to [`assets`](assets).


### PR DESCRIPTION
Closes #5 

Clarifies how jekyll converts markdown to html and replaces the file extension when building.