### PR TITLE
Add quotes for attribute value in navbar

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -39,7 +39,7 @@
 
       <li>
         <a href="{{subitem.url}}"
-          class={{subitem_state}}>
+          class="{{subitem_state}}">
           {{subitem.text}}
           {% if subitem.external %}
           <img src="/assets/images/link-external.png">


### PR DESCRIPTION
The preprocessed HTML includes unquoted values otherwise.

Use "View Page Source" on https://in-toto.github.io/ and search for `class=>` to see occurrences in the wild.

(I found this while adapting this repo for @EdgeNet-project.)